### PR TITLE
Add connection_status()

### DIFF
--- a/orbi/orbi.py
+++ b/orbi/orbi.py
@@ -2,15 +2,25 @@ import base64
 import urllib2
 import re
 
+
 def statistics(username, password):
-    request = urllib2.Request('http://orbilogin.com/RST_statistic.htm')
-    base64string = base64.encodestring('%s:%s' % (username, password)).replace('\n', '')
-    request.add_header("Authorization", "Basic %s" % base64string)
+    return get('RST_statistic', username, password)
+
+
+def connection_status(username, password):
+    return get('RST_conn_status', username, password)
+
+
+def get(url, username, password):
+    request = urllib2.Request('http://orbilogin.com/{}.htm'.format(url))
+    base64string = base64.encodestring('{}:{}'.format(username, password)).strip('\n')
+    request.add_header("Authorization", "Basic {}".format(base64string))
 
     response = urllib2.urlopen(request)
     html = response.read()
-
-    js_var_pattern = re.compile(r'^var (?P<name>[A-Za-z_0-9]+?)\s*?="?(?P<value>.*?)"?;$', flags=re.MULTILINE | re.UNICODE)
+    js_var_pattern = re.compile(
+        r'^var (?P<name>[A-Za-z_0-9]+?)\s*?="?(?P<value>.*?)"?;$',
+        flags=re.MULTILINE | re.UNICODE)
     matches = re.findall(js_var_pattern, html)
 
     response.close()


### PR DESCRIPTION
* add `connection_status()` function
* add a `get()` function to DRY things

```
>>> c = orbi.connection_status('admin', '<the_password>')
>>> pp = pprint.PrettyPrinter(depth=6)
>>> pp.pprint(c)
{'ac_router_flag': '1',
 'access_control_flag': '1',
 'adv_coexistence_flag': '1',
 'airtime_fairness_flag': '0',
 'an_coexist_flag': '0',
 'an_mode1_value': '173',
 'an_mode2_value': '400',
 'an_mode3_value': '866',
 'an_router_flag': '1',
 'ap_ip_mode': ' "1',
 'ap_mode_detection_flag': '1',
 'apmode_flag': '1',
 'auto_conn_flag': '1',
 'basic_coexistence_flag': '0',
 'bgn_mode1_value': '54',
 'bgn_mode2_value': '192',
 'bgn_mode3_value': '400',
 'bigpond_flag': '0',
 'block_sites_flag': '1',
 'bpa_uptime': '0',
 'bridge_flag': '1',
 'bridge_iptv_flag': '0',
 'bt_igmp_flag': '1',
 'business_ap_detect': '0',
 'circle_avaliable_note': '0',
 'consolidate_device_name': '1',
 'ddns_3322_router_flag': '1',
 'ddns_no_ip_flag': '1',
 'ddns_oray_router_flag': '1',
 'ddns_wildcards_flag': '1',
 'dfs_australia_router_flag': '0',
 'dfs_canada_router_flag': '0',
 'dfs_channel_router_flag': '0',
 'dfs_europe_router_flag': '0',
 'dfs_japan_router_flag': '0',
 'dfs_radar_detect_flag': '1',
 'dhcpc_lease_obtain': '3653',
 'dhcpc_lease_time': '600',
 'dns_third_flag': '1',
 'dsl_enable_flag': '0',
 'dsl_wan_preference': '',
 'enable_vlan_pppoe_support': '1',
 'forward_range_flag': '1',
 'fragment_an_flag': '0',
 'geniecloud_flag': '1',
 'gui_region': 'English',
 'have_advanced_qos': '0',
 'have_broadband': '0',
 'have_dynamic_qos': '1',
 'have_email_flag': '1',
 'have_enterprise': '0',
 'have_green_download': '0',
 'have_ipmac_flag': '0',
 'have_lte_flag': '0',
 'have_mapt': '0',
 'have_speedtest_menu': '0',
 'have_vault': '0',
 'have_wifi_flag': '1',
 'hdd_multi_user': '0',
 'host_name': 'Orbi',
 'igmp_flag': '1',
 'info_get_dns1': '192.168.1.5',
 'info_get_dns2': '',
 'info_get_dns3': '',
 'info_get_gateway': 'xxx.yyy.zzz.1',
 'info_get_wanip': 'xxx.yyy.zzz.13',
 'info_get_wanmask': '255.255.248.0',
 'info_get_wanproto': 'dhcp',
 'internet_type': '1',
 'ipv6_6rd_flag': '1',
 'ipv6_auto_detect': '1',
 'ipv6_dhcp_flag': '1',
 'ipv6_dns_manual': '1',
 'ipv6_flag': '1',
 'ipv6_pppoe_flag': '1',
 'ipv6_static_route': '0',
 'l2tp_flag': '1',
 'lan_ports_num': '3',
 'logs_checkbox_flag': '1',
 'master': 'admin',
 'max_bandwidth': '1000',
 'mobile_conn_flag': '0',
 'monthly_limit_reached': '',
 'mu_mimo_flag': '1',
 'multi_lang_router_flag': '1',
 'netgear_region': 'NA',
 'new_multiple_lang': '1',
 'parental_ctrl_flag': '1',
 'port_forwarding_flag': '1',
 'port_triggering_flag': '1',
 'ppp_uptime': '0',
 'pppoe_intranet_flag': '1',
 'pppoe_mac_router_flag': '1',
 'priority_zone_flag': '0',
 'qos_router_flag': '1',
 'qtn_api_statistics_flag': '0',
 'rae_flag': '1',
 'readyShare_print': '0',
 'readycloud_flag': '0',
 'russian_ppp_flag': '1',
 'russian_pppoe_flag': '0',
 'show_edit_button': '1',
 'speedtest_flag': '1',
 'super_wifi_flag': '1',
 'support_arlo': '0',
 'support_ht160_flag': '0',
 'support_netgear_ddns': '1',
 'support_qos': '0',
 'support_qos_trusted_ip': '0',
 'tivo_flag': '1',
 'tr069_router_flag': '0',
 'traffic_router_flag': '1',
 'transmit_router_flag': '1',
 'txctl_63_33_flag': '0',
 'usb_router_flag': '0',
 'video_router_flag': '1',
 'vlan_iptv_flag': '1',
 'vlan_sb_flag': '0',
 'vpn_show_flag': '1',
 'vpn_smartphone_flag': '1',
 'wds_router_flag': '0',
 'wds_support_wpa': '0'}

```